### PR TITLE
refactor: flag to determine whether to use vehicle id or vin in API requests

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -43,7 +43,7 @@ class TeslaCar:
     by :meth:`teslajsonpy.controller.generate_car_objects`.
     """
 
-    def __init__(self, car: dict, controller, vehicle_data: dict) -> None:
+    def __init__(self, car: dict, controller, vehicle_data: dict, use_vin_as_vehicle_id: bool) -> None:
         """Initialize TeslaCar."""
         self._car = car
         self._controller = controller
@@ -52,6 +52,7 @@ class TeslaCar:
         self._previous_driver_temp = self.driver_temp_setting
         self._previous_fan_status = self.fan_status
         self._previous_passenger_temp = self.passenger_temp_setting
+        self._use_vin_as_vehicle_id = use_vin_as_vehicle_id
 
     @property
     def display_name(self) -> str:
@@ -751,7 +752,8 @@ class TeslaCar:
             **kwargs: Any additional parameters for the api call
 
         """
-        path_vars = {"vehicle_id": self.vin}
+        car_api_id = self.vin if self._use_vin_as_vehicle_id else self.id
+        path_vars = {"vehicle_id": car_api_id}
         if additional_path_vars:
             path_vars.update(additional_path_vars)
 
@@ -1127,7 +1129,7 @@ class TeslaCar:
 
     async def wake_up(self) -> None:
         """Send command to wake up."""
-        await self._controller.wake_up(car_vin=self.vin)
+        await self._controller.wake_up(car_id=self.id)
 
     async def toggle_trunk(self) -> None:
         """Actuate rear trunk."""

--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -1318,15 +1318,16 @@ class Controller:
 
         # Old @wake_up decorator condensed here
         if wake_if_asleep:
-            # At this point the car_api_id contains either the car_id or the vin
             car_api_id = path_vars.get("vehicle_id")
-            car_vin = car_api_id if self._use_vin_as_vehicle_id else self._id_to_vin(car_api_id)
-            car_id = car_api_id if not self._use_vin_as_vehicle_id else self._vin_to_id(car_api_id)
-
-            if not car_id:
+            if not car_api_id:
                 raise ValueError(
                     "wake_if_asleep only supported on endpoints with 'vehicle_id' path variable"
                 )
+
+            # At this point the car_api_id contains either the car_id or the vin
+            car_vin = car_api_id if self._use_vin_as_vehicle_id else self._id_to_vin(car_api_id)
+            car_id = car_api_id if not self._use_vin_as_vehicle_id else self._vin_to_id(car_api_id)
+
             # If we already know the car is asleep, go ahead and wake it
             if not self.is_car_online(car_id=car_id, vin=car_vin):
                 await self.wake_up(car_id=car_id)


### PR DESCRIPTION
logic bases itself on the presence/absence of the api_proxy_url config entry.
if it is present -> assume new API and use vin
if it is not -> assume legacy API and use vehicle id